### PR TITLE
Streampipes 289

### DIFF
--- a/streampipes-connect-adapters/src/main/java/org/apache/streampipes/connect/adapters/opcua/OpcUa.java
+++ b/streampipes-connect-adapters/src/main/java/org/apache/streampipes/connect/adapters/opcua/OpcUa.java
@@ -88,7 +88,7 @@ public class OpcUa {
     }
 
     public OpcUa(String opcServer, int opcServerPort, int namespaceIndex, String nodeId) {
-        this("opc.tcp://" + opcServer + ":" + opcServerPort, namespaceIndex, nodeId);
+        this( opcServer + ":" + opcServerPort, namespaceIndex, nodeId);
     }
 
     public OpcUa(String opcServerURL, int namespaceIndex, String nodeId, String username, String password) {

--- a/streampipes-connect-adapters/src/main/java/org/apache/streampipes/connect/adapters/opcua/OpcUaAdapter.java
+++ b/streampipes-connect-adapters/src/main/java/org/apache/streampipes/connect/adapters/opcua/OpcUaAdapter.java
@@ -251,11 +251,17 @@ public class OpcUaAdapter extends SpecificDataStreamAdapter {
         String selectedAlternativeConnection = extractor.selectedAlternativeInternalId(OPC_HOST_OR_URL);
         String selectedAlternativeAuthentication = extractor.selectedAlternativeInternalId(ACCESS_MODE);
 
+        String serverAddress = extractor.singleValueParameter(OPC_SERVER_URL, String.class);
+        if (!serverAddress.startsWith("opc.tcp://")) {
+            serverAddress = "opc.tcp://" + serverAddress;
+        };
+
         if (selectedAlternativeConnection.equals(OPC_URL)) {
-            this.opcUaServer = extractor.singleValueParameter(OPC_SERVER_URL, String.class);
+
+            this.opcUaServer = serverAddress;
             this.selectedURL = true;
         } else {
-            this.opcUaServer = extractor.singleValueParameter(OPC_SERVER_HOST, String.class);
+            this.opcUaServer = serverAddress;
             this.port = extractor.singleValueParameter(OPC_SERVER_PORT, String.class);
             this.selectedURL = false;
         }

--- a/streampipes-connect-adapters/src/main/resources/org.apache.streampipes.connect.adapters.opcua/strings.en
+++ b/streampipes-connect-adapters/src/main/resources/org.apache.streampipes.connect.adapters.opcua/strings.en
@@ -12,10 +12,10 @@ OPC_HOST.title=Host/Port
 OPC_HOST.description=
 
 OPC_SERVER_URL.title=URL
-OPC_SERVER_URL.description=Example: opc.tcp://test-server.com:4840
+OPC_SERVER_URL.description=Example: opc.tcp://test-server.com:4840,
 
 OPC_SERVER_HOST.title=Host
-OPC_SERVER_HOST.description=Example: test-server.com (No leading opc.tcp://)
+OPC_SERVER_HOST.description=Example: test-server.com, opc.tcp://test-server.com)
 
 OPC_SERVER_PORT.title=Port
 OPC_SERVER_PORT.description=Example: 4840

--- a/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/opcua/OpcUa.java
+++ b/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/opcua/OpcUa.java
@@ -66,6 +66,7 @@ public class OpcUa implements EventSink<OpcUaParameters> {
 		compatibleDataTypes.put(Float.class, new Class[] {Double.class, String.class});
 		compatibleDataTypes.put(Integer.class, new Class[]{Double.class, Float.class, String.class});
 		compatibleDataTypes.put(Boolean.class, new Class[]{String.class});
+		compatibleDataTypes.put(String.class, new Class[]{String.class});
 	}
 
 	@Override

--- a/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/opcua/OpcUa.java
+++ b/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/opcua/OpcUa.java
@@ -21,6 +21,7 @@ package org.apache.streampipes.sinks.databases.jvm.opcua;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.api.config.OpcUaClientConfig;
 import org.eclipse.milo.opcua.stack.client.DiscoveryClient;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.*;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
@@ -32,7 +33,7 @@ import org.apache.streampipes.vocabulary.XSD;
 import org.apache.streampipes.wrapper.context.EventSinkRuntimeContext;
 import org.apache.streampipes.wrapper.runtime.EventSink;
 
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -44,6 +45,28 @@ public class OpcUa implements EventSink<OpcUaParameters> {
 	private OpcUaParameters params;
 	private String serverUrl;
 	private NodeId node;
+	private Class targetDataType;
+	private Class sourceDataType;
+
+	// define a mapping of StreamPipes data types to Java classes
+	private static HashMap<String, Class> XSDMatchings = new HashMap<>();
+	static {
+		XSDMatchings.put(XSD._double.toString(), Double.class);
+		XSDMatchings.put(XSD._integer.toString(), Integer.class);
+		XSDMatchings.put(XSD._int.toString(), Integer.class);
+		XSDMatchings.put(XSD._boolean.toString(), Boolean.class);
+		XSDMatchings.put(XSD._string.toString(), String.class);
+		XSDMatchings.put(XSD._float.toString(), Float.class);
+	}
+
+	// define potential mappings, left can be mapped to right
+	private static HashMap<Class, Class[]> compatibleDataTypes = new HashMap<>();
+	static {
+		compatibleDataTypes.put(Double.class, new Class[] {Float.class, String.class});
+		compatibleDataTypes.put(Float.class, new Class[] {Double.class, String.class});
+		compatibleDataTypes.put(Integer.class, new Class[]{Double.class, Float.class, String.class});
+		compatibleDataTypes.put(Boolean.class, new Class[]{String.class});
+	}
 
 	@Override
 	public void onInvocation(OpcUaParameters parameters, EventSinkRuntimeContext runtimeContext) throws
@@ -90,6 +113,20 @@ public class OpcUa implements EventSink<OpcUaParameters> {
 			throw new SpRuntimeException("Could not connect to OPC-UA server: " + serverUrl);
 		}
 
+		// check whether input data type and target data type are compatible
+		try {
+			Variant value = opcUaClient.getAddressSpace().getVariableNode(node).readValue().getValue();
+			targetDataType = value.getValue().getClass();
+			sourceDataType = XSDMatchings.get(params.getMappingPropertyType());
+			if (!sourceDataType.equals(targetDataType)) {
+				if (! Arrays.stream(compatibleDataTypes.get(sourceDataType)).anyMatch(dt -> dt.equals(targetDataType))) {
+					throw new SpRuntimeException("Data Type of event of target node are not compatible");
+				}
+			}
+		} catch (UaException e) {
+			throw new SpRuntimeException("DataType of target node could not be determined: " + node.getIdentifier());
+		}
+
 	}
 
 	@Override
@@ -129,18 +166,17 @@ public class OpcUa implements EventSink<OpcUaParameters> {
 
 	private Variant getValue(Event inputEvent) {
 		Variant result = null;
-		String mappingType = this.params.getMappingPropertyType();
 		PrimitiveField propertyPrimitive = inputEvent.getFieldBySelector(this.params.getMappingPropertySelector()).getAsPrimitive();
 
-		if (mappingType.equals(XSD._integer.toString())){
+		if (targetDataType.equals(Integer.class)){
 			result = new Variant(propertyPrimitive.getAsInt());
-		} else if (mappingType.equals(XSD._double.toString())){
+		} else if (targetDataType.equals(Double.class)){
 			result = new Variant(propertyPrimitive.getAsDouble());
-		} else if (mappingType.equals(XSD._boolean.toString())){
+		} else if (targetDataType.equals(Boolean.class)){
 			result = new Variant(propertyPrimitive.getAsBoolean());
-		} else if (mappingType.equals(XSD._float.toString())){
+		} else if (targetDataType.equals(Float.class)){
 			result = new Variant(propertyPrimitive.getAsFloat());
-		} else if (mappingType.equals(XSD._string.toString())){
+		} else if (targetDataType.equals(String.class)){
 			result = new Variant(propertyPrimitive.getAsString());
 		}
 

--- a/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/opcua/OpcUa.java
+++ b/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/opcua/OpcUa.java
@@ -32,7 +32,6 @@ import org.apache.streampipes.vocabulary.XSD;
 import org.apache.streampipes.wrapper.context.EventSinkRuntimeContext;
 import org.apache.streampipes.wrapper.runtime.EventSink;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -51,7 +50,12 @@ public class OpcUa implements EventSink<OpcUaParameters> {
 			SpRuntimeException {
 		LOG = parameters.getGraph().getLogger(OpcUa.class);
 
-		serverUrl = "opc.tcp://" + parameters.getHostName() + ":" + parameters.getPort();
+		if (!parameters.getHostName().startsWith("opc.tcp://")){
+			serverUrl= "opc.tcp://" + parameters.getHostName() + ":" + parameters.getPort();
+		}
+		else {
+			serverUrl = parameters.getHostName() + ":" + parameters.getPort();
+		}
     if (isInteger(parameters.getNodeId())) {
 			int integerNodeId = Integer.parseInt(parameters.getNodeId());
 			node = new NodeId(parameters.getNameSpaceIndex(), integerNodeId);
@@ -65,7 +69,7 @@ public class OpcUa implements EventSink<OpcUaParameters> {
 		List<EndpointDescription> endpoints;
 
 		try {
-//			endpoints = UaTcpStackClient.getEndpoints(serverUrl).get();
+
 			endpoints = DiscoveryClient.getEndpoints(serverUrl).get();
 
 			EndpointDescription endpoint = endpoints

--- a/streampipes-sinks-databases-jvm/src/main/resources/org.apache.streampipes.sinks.databases.jvm.opcua/strings.en
+++ b/streampipes-sinks-databases-jvm/src/main/resources/org.apache.streampipes.sinks.databases.jvm.opcua/strings.en
@@ -1,8 +1,8 @@
 org.apache.streampipes.sinks.databases.jvm.opcua.title=OPC-UA
 org.apache.streampipes.sinks.databases.jvm.opcua.description=Writes values in an OPC-UA server
 
-opc_host.title=Hostname
-opc_host.description=The hostname of the OPC-UA server (Example: opc-ua-server.com, no leading opc.tcp://)
+opc_host.title=Host Address
+opc_host.description=The host address of the OPC-UA server (Example: opc-ua-server.com, opc.tcp://opc-ua-server.com)
 
 opc_port.title=Port
 opc_port.description=The port of the OPC-UA server (Example: 4840)


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
-->
Users reported that the OPC UA sink does sometimes not write the incoming event values as expected.
After investigation, this issue could be traced back to data type incompatibilities

### Approach
<!--
Describe how you are implementing the solutions along with the design details.
-->
Compare data types of the incoming event and the target OPC UA node.
Check them for compatibility.
If not compatiblie, raise SpRuntimeException

### Samples
<!--
Provide high-level details about the samples related to this feature.
-->

### Remarks
<!--
List related issues/PRs, link to discussions in the mailing list, todo items, or any other notes related to the PR.
-->
Fixes: [STREAMPIPES-289](https://issues.apache.org/jira/browse/STREAMPIPES-289)
